### PR TITLE
Add CONF_START for sshd configuration

### DIFF
--- a/scripts/server/services.conf.example
+++ b/scripts/server/services.conf.example
@@ -56,4 +56,5 @@ CONF_REQUIRED["battery"]="php"
 #######################################
 CONF_PROCESS["sshd"]="sshd"
 CONF_PIDFILE["sshd"]="${PREFIX}/var/run/sshd.pid"
+CONF_START["sshd"]="sshd"
 CONF_SKIP_STOP["sshd"]="true"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add CONF_START for sshd in services.conf.example so the service scripts know how to start sshd. This fixes the missing start configuration and ensures start/restart actions work properly.

<sup>Written for commit 12c13fa0403308624e085fc6aa855d7ed594eed0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

